### PR TITLE
Clean up & fix search path for sound clips

### DIFF
--- a/GameControllerStartPatch.cs
+++ b/GameControllerStartPatch.cs
@@ -1,14 +1,8 @@
-﻿using System.Collections;
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Security.Permissions;
+﻿using System.Security.Permissions;
 using HarmonyLib;
 using UnityEngine;
-using UnityEngine.Events;
-using UnityEngine.PostProcessing;
-using Logger = BepInEx.Logging.Logger;
 
-[assembly: SecurityPermission(System.Security.Permissions.SecurityAction.RequestMinimum, SkipVerification = true)]
+[assembly: SecurityPermission(SecurityAction.RequestMinimum, SkipVerification = true)]
 
 namespace LowLatencyTromboneChamp
 {
@@ -42,7 +36,6 @@ namespace LowLatencyTromboneChamp
 			__instance.currentnotesound.Stop();
 
 			Plugin.Instance.PlaySound(Mathf.Abs(num2 - 14));
-			return;
 		}
 	}
 	
@@ -53,7 +46,6 @@ namespace LowLatencyTromboneChamp
 		static void Postfix(GameController __instance)
 		{
 			Plugin.Instance.currentStream?.Stop();
-			return;
 		}
 	}
 	
@@ -68,8 +60,6 @@ namespace LowLatencyTromboneChamp
 			{
 				Plugin.Instance.currentStream?.SetSpeed(__instance.currentnotesound.pitch);
 			}
-
-			return;
 		}
 	}
 }

--- a/LowLatencyTromboneChamp.csproj
+++ b/LowLatencyTromboneChamp.csproj
@@ -1,76 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net472</TargetFramework>
+        <AssemblyName>LowLatencyTromboneChamb</AssemblyName>
+        <Description>LowLatencyTromboneChamb</Description>
+        <Version>1.0.0</Version>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>LowLatencyTromboneChamb</AssemblyName>
-    <Description>LowLatencyTromboneChamb</Description>
-    <Version>1.0.0</Version>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>latest</LangVersion>
-    <YourTromboneChampInstallationPath>D:\Games\SteamLibrary\steamapps\common\TromboneChamp</YourTromboneChampInstallationPath>
-  </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all"/>
+        <PackageReference Include="BepInEx.Core" Version="5.*"/>
+        <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*"/>
+        <PackageReference Include="ILRepack" Version="2.0.18"/>
+        <PackageReference Include="TromboneChamp.GameLibs" Version="1.9.5"/>
+        <Reference Include="ASIO.NET">
+            <HintPath>Libs\ASIO.NET.dll</HintPath>
+        </Reference>
+    </ItemGroup>
 
-  <PropertyGroup Condition="Exists('..\..\TromboneChamp_Data')">
-       <TromboneChampDir>..\..</TromboneChampDir>
-   </PropertyGroup>
-
-   <PropertyGroup Condition="!Exists('..\..\TromboneChamp_Data')">
-       <TromboneChampDir>$(YourTromboneChampInstallationPath)</TromboneChampDir>
-   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.Core" Version="5.*" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-    <PackageReference Include="ILRepack" Version="2.0.18" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
-  </ItemGroup>
-
-  <ItemGroup>
-   <Reference Include="UnityEngine.AudioModule">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
-   </Reference>
-   <Reference Include="UnityEngine.CoreModule">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-   </Reference>
-   <Reference Include="UnityEngine.UnityWebRequestAudioModule.dll">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
-   </Reference>
-   <Reference Include="UnityEngine.UnityWebRequestModule.dll">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
-   </Reference>
-   <Reference Include="UnityEngine.UnityWebRequestWWWModule">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
-   </Reference>
-   <Reference Include="UnityEngine.UnityWebRequestTextureModule">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
-   </Reference>
-   <Reference Include="UnityEngine">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.dll</HintPath>
-   </Reference>
-   <Reference Include="UnityEngine.AssetBundleModule">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
-   </Reference>
-   <Reference Include="Assembly-CSharp">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\Assembly-CSharp-nstrip.dll</HintPath>
-   </Reference>
-   <Reference Include="Assembly-CSharp-firstpass">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-   </Reference>
-   <Reference Include="UnityEngine.UI">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.UI.dll</HintPath>
-   </Reference>
-   <Reference Include="UnityEngine.ImageConversionModule">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
-   </Reference>
-   <Reference Include="UnityEngine.IMGUIModule">
-     <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
-   </Reference>
-      <Reference Include="ASIO.NET">
-          <HintPath>Libs\ASIO.NET.dll</HintPath>
-      </Reference>
- </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all"/>
+    </ItemGroup>
 </Project>

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,158 +1,137 @@
-﻿using BepInEx;
-using BepInEx.Logging;
-using HarmonyLib;
-using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using ASIO.NET;
+using BepInEx;
+using BepInEx.Logging;
+using HarmonyLib;
 using UnityEngine;
-using UnityEngine.Networking;
-using UnityEngine.SceneManagement;
 
+namespace LowLatencyTromboneChamp;
 
-namespace LowLatencyTromboneChamp
+[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+public class Plugin : BaseUnityPlugin
 {
-    [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
-    public class Plugin : BaseUnityPlugin
+    public static Plugin Instance;
+    public AudioClip currentClip;
+    public bool isAsioInitted;
+    public bool areSamplesloaded;
+    public int loadedClipCount;
+
+    public bool hide;
+    public SoundStream currentStream;
+
+    public Asio deviceOut;
+
+    private void Awake()
     {
-        public static Plugin Instance;
-        public AudioClip currentClip;
-        
-        private void Awake()
+        Instance = this;
+        LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
+        var harmony = new Harmony(PluginInfo.PLUGIN_GUID);
+        harmony.PatchAll();
+    }
+
+    private void OnGUI()
+    {
+        if (hide) return;
+        if (!isAsioInitted)
         {
-            Instance = this;
-            LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
-            var harmony = new Harmony(PluginInfo.PLUGIN_GUID);
-            harmony.PatchAll();
-        }
-        
-
-        #region logging
-        internal static void LogDebug(string message) => Instance.Log(message, LogLevel.Debug);
-        internal static void LogInfo(string message) => Instance.Log(message, LogLevel.Info);
-        internal static void LogWarning(string message) => Instance.Log(message, LogLevel.Warning);
-        internal static void LogError(string message) => Instance.Log(message, LogLevel.Error);
-        private void Log(string message, LogLevel logLevel) => Logger.Log(logLevel, message);
-        #endregion
-        
-        public Asio deviceOut;
-        public bool isAsioInitted = false;
-        public bool areSamplesloaded = false;
-        public SoundStream currentStream = null;
-        public int loadedClipCount = 0;
-
-        //Game broke ASIO, so we hack it til it works again
-        public void LoadDefaultTromboneSoundsHack()
-        {
-            
-            var path = Path.Combine(Paths.BepInExRootPath, "plugins/LowLatencyAudioClips/");
-            
-            
-            var clips = new List<string>()
-            {
-                "t2_tromboneC1.wav",
-                "t2_tromboneD1.wav",
-                "t2_tromboneE1.wav",
-                "t2_tromboneF1.wav",
-                "t2_tromboneG1.wav",
-                "t2_tromboneA1.wav",
-                "t2_tromboneB1.wav",
-                "t2_tromboneC2.wav",
-                "t2_tromboneD2.wav",
-                "t2_tromboneE2.wav",
-                "t2_tromboneF2.wav",
-                "t2_tromboneG2.wav",
-                "t2_tromboneA2.wav",
-                "t2_tromboneB2.wav",
-                "t2_tromboneC3.wav"
-            };
-
-            foreach (var sound in clips)
-            {
-                var filePath = Path.Combine(path, sound);
-                
-                byte[] fileBytes = File.ReadAllBytes (filePath);
-
-                var clip = WavUtility.ToAudioClip(fileBytes);
-                
-                loadedClipCount += 1;
-                var channels = clip.channels;
-                var sampleRate = clip.frequency;
-                var data = new float[clip.samples * channels];
-                clip.GetData(data, 0);
-                deviceOut.Load(data, (uint)sampleRate, (uint)channels);
-                areSamplesloaded = true;
-                
-            }
-            
-        }
-
-        
-        public void InitTromboneClips(AudioClip[] clips)
-        {
-            //Unloads soundset
-            /*
-            while (loadedClipCount > 0)
-            {
-                deviceOut.UnLoad(loadedClipCount);
-                loadedClipCount -= 1;
-            }
-
-            //Load trombone soundset
-            foreach (var clip in clips)
-            {
-                loadedClipCount += 1;
-                Logger.LogInfo(clip.name);
-                var channels = clip.channels;
-                var sampleRate = clip.frequency;
-                var data = new float[clip.samples * channels];
-                clip.GetData(data, 0);
-                deviceOut.Load(data, (uint)sampleRate, (uint)channels);
-                areSamplesloaded = true;
-            }*/
-        }
-        
-        public void PlaySound(int id)
-        {
-            Logger.LogWarning("Playing Asio Note!!");
-            if (currentStream != null) currentStream.Stop();
-            currentStream = deviceOut.Play(
-                soundID: id+1,
-                outChannels: new uint[] { 0, 1 },
-                looping: true);
-            
-        }
-
-        public bool hide = false;
-        private void OnGUI()
-        {
-            if (hide) return;
-            if (!isAsioInitted)
-            {
-                GUILayout.Label("Select Your Asio Device");
-                foreach (var device in Asio.GetDeviceNames())
+            GUILayout.Label("Select Your Asio Device");
+            foreach (var device in Asio.GetDeviceNames())
+                if (GUILayout.Button(device))
                 {
-                    if (GUILayout.Button(device))
-                    {
-                        deviceOut = Asio.CreatePlayer(device, 48000);
-                        isAsioInitted = true;
-                        LoadDefaultTromboneSoundsHack();
-                    }
+                    deviceOut = Asio.CreatePlayer(device, 48000);
+                    isAsioInitted = true;
+                    LoadDefaultTromboneSoundsHack();
                 }
-            }
-            else
-            {
-                if (GUILayout.Button("Show Asio Panel"))
-                {
-                    deviceOut.ShowControlPanel();
-                }
-                if (GUILayout.Button("Hide"))
-                {
-                    hide = true;
-                }
-            }
+        }
+        else
+        {
+            if (GUILayout.Button("Show Asio Panel")) deviceOut.ShowControlPanel();
 
+            if (GUILayout.Button("Hide")) hide = true;
         }
     }
+
+    //Game broke ASIO, so we hack it til it works again
+    public void LoadDefaultTromboneSoundsHack()
+    {
+        var pluginDir = Path.GetDirectoryName(Info.Location); // get the directory the DLL is in
+        var path = Path.Combine(pluginDir ?? Paths.PluginPath, "LowLatencyAudioClips/");
+
+        var clips = new List<string>
+        {
+            "t2_tromboneC1.wav",
+            "t2_tromboneD1.wav",
+            "t2_tromboneE1.wav",
+            "t2_tromboneF1.wav",
+            "t2_tromboneG1.wav",
+            "t2_tromboneA1.wav",
+            "t2_tromboneB1.wav",
+            "t2_tromboneC2.wav",
+            "t2_tromboneD2.wav",
+            "t2_tromboneE2.wav",
+            "t2_tromboneF2.wav",
+            "t2_tromboneG2.wav",
+            "t2_tromboneA2.wav",
+            "t2_tromboneB2.wav",
+            "t2_tromboneC3.wav"
+        };
+
+        foreach (var sound in clips)
+        {
+            var filePath = Path.Combine(path, sound);
+
+            var fileBytes = File.ReadAllBytes(filePath);
+
+            var clip = WavUtility.ToAudioClip(fileBytes);
+
+            loadedClipCount += 1;
+            var channels = clip.channels;
+            var sampleRate = clip.frequency;
+            var data = new float[clip.samples * channels];
+            clip.GetData(data, 0);
+            deviceOut.Load(data, (uint)sampleRate, (uint)channels);
+            areSamplesloaded = true;
+        }
+    }
+
+    public void PlaySound(int id)
+    {
+        Logger.LogWarning("Playing Asio Note!!");
+        currentStream?.Stop();
+        currentStream = deviceOut.Play(
+            id + 1,
+            new uint[] { 0, 1 },
+            looping: true);
+    }
+
+
+    #region logging
+
+    internal static void LogDebug(string message)
+    {
+        Instance.Log(message, LogLevel.Debug);
+    }
+
+    internal static void LogInfo(string message)
+    {
+        Instance.Log(message, LogLevel.Info);
+    }
+
+    internal static void LogWarning(string message)
+    {
+        Instance.Log(message, LogLevel.Warning);
+    }
+
+    internal static void LogError(string message)
+    {
+        Instance.Log(message, LogLevel.Error);
+    }
+
+    private void Log(string message, LogLevel logLevel)
+    {
+        Logger.Log(logLevel, message);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Did a bunch of cleanup and smacked the big Reformat button for Plugin.cs, so this PR has a lot of noise, but the important bit is this:

```diff
- var path = Path.Combine(Paths.BepInExRootPath, "plugins/LowLatencyAudioClips/");
+ var pluginDir = Path.GetDirectoryName(Info.Location); // get the directory the DLL is in
+ var path = Path.Combine(pluginDir ?? Paths.PluginPath, "LowLatencyAudioClips/");
```